### PR TITLE
URDF and teleop fixes

### DIFF
--- a/vector_common/vector_description/urdf/linear_actuator/vector_linear_actuator.urdf.xacro
+++ b/vector_common/vector_description/urdf/linear_actuator/vector_linear_actuator.urdf.xacro
@@ -43,8 +43,11 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 				</geometry>
 			</collision>
 		    <inertial>
-			    <mass value="2e-06"/>
-			    <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
+                <!--mass value="2e-06"/>
+                <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/-->
+                <mass value="5.098044" />
+                <origin xyz="0.0 0.0 0.5" rpy="0 0 0"/>
+                <inertia ixx="0.02"  ixy="0.0"  ixz="1.0" iyy="-0.03"  iyz="-0.02" izz="0.0" />
 		    </inertial>			    
 		</link>
 		
@@ -70,8 +73,13 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 				    </geometry>
 			    </collision>
 		        <inertial>
-			        <mass value="2e-06"/>
-			        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
+                    <!--mass value="2e-06"/>
+                    <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/-->
+                    <mass value="0.217" />
+                    <origin xyz="0 -0.001 0" rpy="0 0 0"/>
+                    <inertia ixx="0.0" ixy="0.0"  ixz="1.0"
+                             iyy="0.0" iyz="0.0"
+                             izz="0.0" />
 		        </inertial>
 		    </link>
 		</xacro:unless>

--- a/vector_common/vector_description/urdf/manipulation/jaco/jaco.urdf.xacro
+++ b/vector_common/vector_description/urdf/manipulation/jaco/jaco.urdf.xacro
@@ -94,9 +94,11 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
         <joint name="${prefix}shoulder_lift_joint" type="revolute">
             <parent link="${prefix}shoulder_link" />
             <child link = "${prefix}upper_arm_link" />
-            <origin xyz="0 0 -0.11875" rpy="${M_PI/2} ${M_PI/2} 0" />
+            <!--ZERO CONFIG:<origin xyz="0 0 -0.11875" rpy="${M_PI/2} ${M_PI/2} 0" />-->
+            <origin xyz="0 0 -0.11875" rpy="${M_PI/2} ${-M_PI/2} 0" />
             <axis xyz="0 0 1" />
-            <limit lower="-2.238" upper="2.238" effort="3000.5" velocity="0.314"/>
+            <!--ZERO CONFIG:<limit lower="-2.238" upper="2.238" effort="3000.5" velocity="0.314"/>-->
+            <limit lower="${M_PI-2.238}" upper="${M_PI+2.238}" effort="3000.5" velocity="0.314"/>
             <dynamics damping="0.0" friction="0.0"/>
         </joint>
 
@@ -123,9 +125,11 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
         <joint name="${prefix}elbow_joint" type="revolute">
             <parent link="${prefix}upper_arm_link" />
             <child link = "${prefix}forearm_link" />
-            <origin xyz="0.41 0 0.00975" rpy=" 0 ${M_PI} ${M_PI}" />
+            <!--ZERO CONFIG:<origin xyz="0.41 0 0.00975" rpy=" 0 ${M_PI} ${M_PI}" />-->
+            <origin xyz="0.41 0 0.00975" rpy="0 ${M_PI} 0" />
             <axis xyz="0 0 1" />
-            <limit lower="-2.809" upper="2.809" effort="1800.0" velocity="0.314"/>
+            <!--ZERO CONFIG:<limit lower="-2.809" upper="2.809" effort="1800.0" velocity="0.314"/>-->
+            <limit lower="${M_PI-2.809}" upper="${M_PI+2.809}" effort="1800.0" velocity="0.314"/>
             <dynamics damping="0.0" friction="0.0"/>
         </joint>
 
@@ -239,10 +243,19 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 
         <joint name="${prefix}ee_fixed_joint" type="fixed">
             <parent link="${prefix}wrist_3_link" />
-            <child link = "${prefix}ee_link" />
+            <child link = "${prefix}ee_base" />
             <origin xyz="0 0 -0.09380704" rpy="${M_PI} ${M_PI/2} 0" /> <!--0.09380704156-->
         </joint>
-        
+
+        <link name="${prefix}ee_base"/>
+ 
+        <!-- Add in an EEF link for the center of the gripper -->
+        <joint name="${prefix}ee_gripper" type="fixed">
+            <parent link="${prefix}ee_base" />
+            <child link ="${prefix}ee_link" />
+            <origin xyz="0.13 0 0" />
+        </joint>
+
         <link name="${prefix}ee_link"/>
         
         <xacro:jaco_arm_transmission prefix="${prefix}" />

--- a/vector_common/vector_description/urdf/vector.urdf.xacro
+++ b/vector_common/vector_description/urdf/vector.urdf.xacro
@@ -43,7 +43,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
             <odometryRate>30.0</odometryRate>
             <robotBaseFrame>base_link</robotBaseFrame>
             <publishOdometryTf>0</publishOdometryTf>
-            <yaw_velocity_p_gain>10000.0</yaw_velocity_p_gain>
+            <yaw_velocity_p_gain>100.0</yaw_velocity_p_gain>
             <x_velocity_p_gain>10000.0</x_velocity_p_gain>
             <y_velocity_p_gain>10000.0</y_velocity_p_gain>
         </plugin>
@@ -78,13 +78,13 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
         </xacro:if>
         
         <xacro:if value="$(optenv VECTOR_HAS_ROBOTIQ_GRIPPER false)">
-            <xacro:robotiq_85_gripper prefix="right_" parent="right_ee_link" >
+            <xacro:robotiq_85_gripper prefix="right_" parent="right_ee_base" >
                 <origin xyz="0 0 0" rpy="0 0 0"/>
             </xacro:robotiq_85_gripper>
         
         
             <xacro:if value="$(optenv VECTOR_HAS_TWO_ROBOTIQ_GRIPPERS false)">
-                <xacro:robotiq_85_gripper prefix="left_" parent="left_ee_link" >
+                <xacro:robotiq_85_gripper prefix="left_" parent="left_ee_base" >
                     <origin xyz="0 0 0" rpy="0 0 0"/>
                 </xacro:robotiq_85_gripper>
             </xacro:if>


### PR DESCRIPTION
Merge in changes specific to the URDF in "vector_description" and support for teleop in simulation using "hlpr_gazebo"

URDF changes:
- Actual mass and inertia values for the linear actuator (pulled from CAD files)
- Added in an extra "dummy" link that allows for planning from the center of the gripper

Teleop changes:
- Support for pan/tilt and linear actuator changes in the vector_ros->vector_teleop_full_system node