### PR TITLE
Fixed CMake install script to point to the actual name of the script

### DIFF
--- a/vector_robot/vector_bringup/CMakeLists.txt
+++ b/vector_robot/vector_bringup/CMakeLists.txt
@@ -12,7 +12,7 @@ catkin_package()
 roslaunch_add_file_check(launch)
 
 ## Install ## 
-install(PROGRAMS scripts/install_vector1_core scripts/uninstall_vector1_core
+install(PROGRAMS scripts/install_vector_core scripts/uninstall_vector_core
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 


### PR DESCRIPTION
Small fix to prevent catkin_make install from crashing. Changed the CMake file in vector_bringup to call the actual filename