### PR TITLE
rosdep issues with newly added ira_laser_tools package

### DIFF
--- a/vector_robot/vector_sensor_filters/ira_laser_tools/CMakeLists.txt
+++ b/vector_robot/vector_sensor_filters/ira_laser_tools/CMakeLists.txt
@@ -6,8 +6,6 @@ project(ira_laser_tools)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS laser_geometry roscpp sensor_msgs std_msgs tf dynamic_reconfigure pcl_ros)
 
-#find_package(Eigen3 REQUIRED)
-
 find_package(Eigen3)
 if(NOT EIGEN3_FOUND)
   # Fallback to pkg-config

--- a/vector_robot/vector_sensor_filters/ira_laser_tools/CMakeLists.txt
+++ b/vector_robot/vector_sensor_filters/ira_laser_tools/CMakeLists.txt
@@ -6,7 +6,18 @@ project(ira_laser_tools)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS laser_geometry roscpp sensor_msgs std_msgs tf dynamic_reconfigure pcl_ros)
 
-find_package(Eigen3 REQUIRED)
+#find_package(Eigen3 REQUIRED)
+
+find_package(Eigen3)
+if(NOT EIGEN3_FOUND)
+  # Fallback to pkg-config
+  find_package(PkgConfig)
+  pkg_check_modules(EIGEN3 REQUIRED eigen3)
+else()
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
+add_definitions(${EIGEN3_DEFINITIONS})
+
 
 find_package(PCL REQUIRED)
 

--- a/vector_robot/vector_sensor_filters/ira_laser_tools/CMakeLists.txt
+++ b/vector_robot/vector_sensor_filters/ira_laser_tools/CMakeLists.txt
@@ -55,7 +55,7 @@ generate_dynamic_reconfigure_options(cfg/laserscan_multi_merger.cfg cfg/lasersca
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-   INCLUDE_DIRS
+   INCLUDE_DIRS ${EIGEN3_INCLUDE_DIRS}
 #  LIBRARIES laser_merger
 #  CATKIN_DEPENDS laser_geometry roscpp sensor_msgs std_msgs tf
 #  DEPENDS system_lib
@@ -69,7 +69,7 @@ catkin_package(
 ## Your package locations should be listed before other locations
 include_directories(include
   ${catkin_INCLUDE_DIRS}
-  ${EIGEN_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
   ${PCL_INCLUDE_DIRS}
 )
 

--- a/vector_robot/vector_sensor_filters/ira_laser_tools/package.xml
+++ b/vector_robot/vector_sensor_filters/ira_laser_tools/package.xml
@@ -10,14 +10,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>pcl</build_depend>
+  <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>laser_geometry</build_depend>
   <build_depend>roscpp</build_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>pcl</run_depend>
+  <run_depend>libpcl-all-dev</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>

--- a/vector_robot/vector_sensor_filters/ira_laser_tools/package.xml
+++ b/vector_robot/vector_sensor_filters/ira_laser_tools/package.xml
@@ -9,6 +9,7 @@
   <license>TODO</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_ros</build_depend>


### PR DESCRIPTION
The newly added `ira_laser_tool package` uses an old dependency name for pcl and causes rosdep to error out. This is highly problematic for our travis builds. This definitely breaks the build.

The package.xml references ` <build_depend>pcl</build_depend>` where rosdep no longer lists the package as `pcl`. It is `libpcl-all-dev` [rosdep](https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml).

Changed the package.xml to reflect this.

Also change the CMakeList.txt to check other locations for Eigen3 when it can't find it for compiling with travis