### PR TITLE
change so that we load the kinova arm in a consistent method with nimbus

### DIFF
--- a/vector_common/vector_description/urdf/vector_7dof.urdf.xacro
+++ b/vector_common/vector_description/urdf/vector_7dof.urdf.xacro
@@ -80,9 +80,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     
     <!-- Arms -->
     <xacro:if value="$(optenv VECTOR_HAS_KINOVA_ARM false)"> 
-        <xacro:j2s7s300 base_parent="linear_actuator_link" >
+        <xacro:j2s7s300 base_parent="linear_actuator_link" trans="0.06079866 0 0" rot="${J_PI/2} 0 ${J_PI/2}">
 	    <!-- Note: origin is overwritten in kinova urdf -->
-            <origin xyz="0 0 0" rpy="0 0 0" />
+            <origin xyz="0.06079866 0 0" rpy="${J_PI/2} 0 ${J_PI/2}" />
 	</xacro:j2s7s300>
     </xacro:if>
 


### PR DESCRIPTION
Pulling in small changes so we don't have a prefix in front of the gripper for the 7dof arm. This allows us to be used with a more generic kinova-ros branch.