### PR TITLE
Depend on packages, not metapackages

### DIFF
--- a/vector_common/vector_third_party/vector_third_party/package.xml
+++ b/vector_common/vector_third_party/vector_third_party/package.xml
@@ -10,8 +10,8 @@
     <license>BSD</license>
 
     <buildtool_depend>catkin</buildtool_depend>
-    <run_depend>dynamixel_motor</run_depend>
-    <run_depend>iai_kinect2</run_depend>
+    <run_depend>dynamixel_driver</run_depend>
+    <run_depend>kinect2_bridge</run_depend>
     <run_depend>roboticsgroup_gazebo_plugins</run_depend>
     <run_depend>trac_ik</run_depend>
 

--- a/vector_robot/vector_bringup/package.xml
+++ b/vector_robot/vector_bringup/package.xml
@@ -10,9 +10,9 @@
     <buildtool_depend>catkin</buildtool_depend>
 
     <build_depend>roslaunch</build_depend>
-    <run_depend>vector_common</run_depend>
+    <run_depend>vector_msgs</run_depend>
     <run_depend>vector_upstart</run_depend>
-    <run_depend>vector_sensor_filters</run_depend>
+    <run_depend>range_sensor_filters</run_depend>
     
 	<export>
 	</export>

--- a/vector_robot/vector_robot/package.xml
+++ b/vector_robot/vector_robot/package.xml
@@ -12,8 +12,8 @@
     
     <run_depend>vector_bringup</run_depend>
     <run_depend>vector_upstart</run_depend>
-    <run_depend>vector_sensor_filters</run_depend>
-    <run_depend>vector_common</run_depend>
+    <run_depend>range_sensor_filters</run_depend>
+    <run_depend>vector_msgs</run_depend>
 
     <export>
         <metapackage/>


### PR DESCRIPTION
Broken since catkin tools 4.0+. Packages should not depend on metapackages. In general, metapackages are not designed to be depended on.
See https://github.com/catkin/catkin_tools/issues/370 for a detailed explanation.

